### PR TITLE
Prevent fatal if site changed to a non-Genesis theme

### DIFF
--- a/genesis-connect-woocommerce.php
+++ b/genesis-connect-woocommerce.php
@@ -60,6 +60,11 @@ function gencwooc_setup() {
 	/** Fail silently if WooCommerce is not activated */
 	if ( ! in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) )
 		return;
+	
+	/** Fail silently if Genesis is not active */
+	if ( 'genesis' != get_option( 'template' ) ) {
+		return;
+	}
 
 	/** Environment is OK, let's go! */
 


### PR DESCRIPTION
To duplicate:
* Have WooCommerce + Genesis child theme active.
* Activate plugin
* Switch to a non-Genesis theme

Expected:
The site continues on with the non-Genesis theme

Actual:
Site fatals when loading a template overriden by the plugin:
```
PHP Fatal error:  Uncaught Error: Call to undefined function genesis() in //wp-content/plugins/genesis-connect-woocommerce/templates/archive-product.php:94
Stack trace:
#0 //wp-includes/template-loader.php(74): include()
#1 //wp-blog-header.php(19): require_once('/wordpress/core...')
#2 //index.php(17): require('/wordpress/core...')
#3 {main}
  thrown in //wp-content/plugins/genesis-connect-woocommerce/templates/archive-product.php on line 94
```

To resolve this, when checking if WooCommerce is active, also check if Genesis is active. If either one isn't active, return out early to prevent the plugin from attempting Genesis-specific functionality.