### PR TITLE
Bugfix: do not load archive product template when shop page is not set

### DIFF
--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -63,7 +63,7 @@ function gencwooc_template_loader( $template ) {
 			$template = GCW_TEMPLATE_DIR . '/single-product.php';
 
 	}
-	elseif ( is_post_type_archive( 'product' ) ||  is_page( get_option( 'woocommerce_shop_page_id' ) ) ) {
+	elseif ( is_post_type_archive( 'product' ) ||  is_page( wc_get_page_id( 'shop' ) ) ) {
 
 		$template = locate_template( array( 'woocommerce/archive-product.php' ) );
 


### PR DESCRIPTION
When the shop page is not set `get_option( 'woocommerce_shop_page_id' )` returns an empty string, which "tricks" `is_page()` to return true.  The WooCommerce helper function `wc_get_page_id( 'shop' )` returns `-1` when the shop page is not set, and causes `is_page()` to correctly return false in that case.

Fixes #31