### PR TITLE
Fix wrong text domain

### DIFF
--- a/admin/views/html-notice-needs-genesis.php
+++ b/admin/views/html-notice-needs-genesis.php
@@ -13,6 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div id="message" class="error notice">
 	<p>
-		<?php esc_html_e( 'Genesis Connect for WooCommerce requires a Genesis child theme. Please activate a Genesis theme or disable Genesis Connect.', 'gencwooc' ); ?>
+		<?php esc_html_e( 'Genesis Connect for WooCommerce requires a Genesis child theme. Please activate a Genesis theme or disable Genesis Connect.', 'genesis-connect-woocommerce' ); ?>
 	</p>
 </div>

--- a/admin/views/html-notice-needs-woocommerce.php
+++ b/admin/views/html-notice-needs-woocommerce.php
@@ -13,6 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div id="message" class="error notice">
 	<p>
-		<?php esc_html_e( 'Genesis Connect for WooCommerce requires WooCommerce. Please activate WooCommerce or disable Genesis Connect.', 'gencwooc' ); ?>
+		<?php esc_html_e( 'Genesis Connect for WooCommerce requires WooCommerce. Please activate WooCommerce or disable Genesis Connect.', 'genesis-connect-woocommerce' ); ?>
 	</p>
 </div>

--- a/genesis-connect-woocommerce.php
+++ b/genesis-connect-woocommerce.php
@@ -6,7 +6,7 @@
  * Author: StudioPress
  * Author URI: https://www.studiopress.com/
  * Description: Allows you to seamlessly integrate WooCommerce with the Genesis Framework and Genesis child themes.
- * Text Domain: gencwooc
+ * Text Domain: genesis-connect-woocommerce
  * License: GNU General Public License v2.0 (or later)
  * License URI: http://www.opensource.org/licenses/gpl-license.php
  * Requires PHP: 5.6
@@ -109,5 +109,5 @@ add_action( 'plugins_loaded', 'gencwooc_load_plugin_textdomain' );
  * @since 1.1.0
  */
 function gencwooc_load_plugin_textdomain() {
-	load_plugin_textdomain( 'gencwooc', false, GCW_DIR . '/languages' );
+	load_plugin_textdomain( 'genesis-connect-woocommerce', false, GCW_DIR . '/languages' );
 }

--- a/lib/breadcrumb.php
+++ b/lib/breadcrumb.php
@@ -64,7 +64,7 @@ function gencwooc_get_archive_crumb_filter( $crumb, $args ) {
 				get_post_type_archive_link( 'product' ),
 				$shop_name,
 				$shop_name,
-				$args['sep'] . __( 'Search results for &ldquo;', 'gencwooc' ) . get_search_query() . '&rdquo;'
+				$args['sep'] . __( 'Search results for &ldquo;', 'genesis-connect-woocommerce' ) . get_search_query() . '&rdquo;'
 			);
 		}
 
@@ -111,7 +111,7 @@ function gencwooc_get_archive_crumb_filter( $crumb, $args ) {
 	}
 
 	if ( is_tax( 'product_tag' ) ) {
-		$crumb .= $prepend . __( 'Products tagged &ldquo;', 'gencwooc' ) . single_term_title( '', false ) . _x( '&rdquo;', 'endquote', 'gencwooc' );
+		$crumb .= $prepend . __( 'Products tagged &ldquo;', 'genesis-connect-woocommerce' ) . single_term_title( '', false ) . _x( '&rdquo;', 'endquote', 'genesis-connect-woocommerce' );
 
 		return $crumb;
 	}

--- a/lib/posts-per-page.php
+++ b/lib/posts-per-page.php
@@ -22,7 +22,7 @@ add_filter( 'woocommerce_settings_tabs_array', 'genesis_connect_addon_tab', 50 )
  */
 function genesis_connect_addon_tab( $tabs ) {
 
-	$tabs['gencwooc'] = __( 'Genesis Connect Addons', 'gencwooc' );
+	$tabs['gencwooc'] = __( 'Genesis Connect Addons', 'genesis-connect-woocommerce' );
 
 	return $tabs;
 
@@ -59,15 +59,15 @@ function genesis_connect_get_settings() {
 
 	$settings = array(
 		'gencwooc_section_title' => array(
-			'name' => __( 'Genesis Connect Addons', 'gencwooc' ),
+			'name' => __( 'Genesis Connect Addons', 'genesis-connect-woocommerce' ),
 			'type' => 'title',
-			'desc' => 'Set and save additional WooCommerce settings here.',
+			'desc' => __( 'Set and save additional WooCommerce settings here.', 'genesis-connect-woocommerce' ),
 			'id'   => 'gencwooc_section_title',
 		),
 		'products_per_page'      => array(
-			'name'    => __( 'Products Per Page', 'gencwooc' ),
+			'name'    => __( 'Products Per Page', 'genesis-connect-woocommerce' ),
 			'type'    => 'number',
-			'desc'    => __( 'This setting determines how many products show up on archive pages and may be overridden by filters used in themes and plugins.', 'gencwooc' ),
+			'desc'    => __( 'This setting determines how many products show up on archive pages and may be overridden by filters used in themes and plugins.', 'genesis-connect-woocommerce' ),
 			'id'      => 'gencwooc_products_per_page',
 			'default' => apply_filters( 'genesiswooc_default_products_per_page', get_option( 'posts_per_page' ) ),
 		),

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -175,10 +175,10 @@ function genesiswooc_product_archive() {
 		$shop_page_title   = apply_filters( 'the_title', ( get_option( 'woocommerce_shop_page_title' ) ) ? get_option( 'woocommerce_shop_page_title' ) : $shop_page->post_title, $shop_page->ID );
 		$shop_page_content = $shop_page->post_content;
 	} else {
-		$shop_page_title = __( 'Search Results:', 'gencwooc' ) . ' &ldquo;' . get_search_query() . '&rdquo;';
+		$shop_page_title = __( 'Search Results:', 'genesis-connect-woocommerce' ) . ' &ldquo;' . get_search_query() . '&rdquo;';
 
 		if ( get_query_var( 'paged' ) ) {
-			$shop_page_title .= ' &mdash; ' . __( 'Page', 'gencwooc' ) . ' ' . get_query_var( 'paged' );
+			$shop_page_title .= ' &mdash; ' . __( 'Page', 'genesis-connect-woocommerce' ) . ' ' . get_query_var( 'paged' );
 		}
 
 		$shop_page_content = '';

--- a/widgets/class-gencwooc-featured-products.php
+++ b/widgets/class-gencwooc-featured-products.php
@@ -51,24 +51,24 @@ class Gencwooc_Featured_Products extends WC_Widget {
 				'show_add_to_cart'        => 1,
 				'show_price'              => 1,
 				'more_from_category'      => 0,
-				'more_from_category_text' => __( 'More Products from this Category', 'gencwooc' ),
+				'more_from_category_text' => __( 'More Products from this Category', 'genesis-connect-woocommerce' ),
 			)
 		);
 
 		$this->widget_cssclass    = 'featured-content featuredproducts';
-		$this->widget_name        = __( 'Genesis - Featured Products', 'gencwooc' );
-		$this->widget_description = __( 'Displays featured products with thumbnails', 'gencwooc' );
+		$this->widget_name        = __( 'Genesis - Featured Products', 'genesis-connect-woocommerce' );
+		$this->widget_description = __( 'Displays featured products with thumbnails', 'genesis-connect-woocommerce' );
 		$this->widget_id          = 'featured-products';
 		$this->settings           = array(
 			'title'                   => array(
 				'type'  => 'text',
 				'std'   => '',
-				'label' => __( 'Title', 'gencwooc' ),
+				'label' => __( 'Title', 'genesis-connect-woocommerce' ),
 			),
 			'product_cat'             => array(
 				'type'    => 'select',
 				'std'     => esc_html( $this->defaults['category'] ),
-				'label'   => __( 'Product Category', 'gencwooc' ),
+				'label'   => __( 'Product Category', 'genesis-connect-woocommerce' ),
 				'options' => array(),
 			),
 			'product_num'             => array(
@@ -77,7 +77,7 @@ class Gencwooc_Featured_Products extends WC_Widget {
 				'min'   => 1,
 				'max'   => '',
 				'std'   => absint( $this->defaults['count'] ),
-				'label' => __( 'Products to Show', 'gencwooc' ),
+				'label' => __( 'Products to Show', 'genesis-connect-woocommerce' ),
 			),
 			'product_offset'          => array(
 				'type'  => 'number',
@@ -85,88 +85,88 @@ class Gencwooc_Featured_Products extends WC_Widget {
 				'min'   => 0,
 				'max'   => '',
 				'std'   => absint( $this->defaults['offset'] ),
-				'label' => __( 'Product Offset', 'gencwooc' ),
+				'label' => __( 'Product Offset', 'genesis-connect-woocommerce' ),
 			),
 			'product_show'            => array(
 				'type'    => 'select',
 				'std'     => esc_html( $this->defaults['show_type'] ),
-				'label'   => __( 'Show', 'gencwooc' ),
+				'label'   => __( 'Show', 'genesis-connect-woocommerce' ),
 				'options' => array(
-					''         => __( 'All products', 'gencwooc' ),
-					'featured' => __( 'Featured products', 'gencwooc' ),
-					'onsale'   => __( 'On-sale products', 'gencwooc' ),
+					''         => __( 'All products', 'genesis-connect-woocommerce' ),
+					'featured' => __( 'Featured products', 'genesis-connect-woocommerce' ),
+					'onsale'   => __( 'On-sale products', 'genesis-connect-woocommerce' ),
 				),
 			),
 			'orderby'                 => array(
 				'type'    => 'select',
 				'std'     => esc_html( $this->defaults['orderby'] ),
-				'label'   => __( 'Order by', 'gencwooc' ),
+				'label'   => __( 'Order by', 'genesis-connect-woocommerce' ),
 				'options' => array(
-					'date'  => __( 'Date', 'gencwooc' ),
-					'price' => __( 'Price', 'gencwooc' ),
-					'rand'  => __( 'Random', 'gencwooc' ),
-					'sales' => __( 'Sales', 'gencwooc' ),
+					'date'  => __( 'Date', 'genesis-connect-woocommerce' ),
+					'price' => __( 'Price', 'genesis-connect-woocommerce' ),
+					'rand'  => __( 'Random', 'genesis-connect-woocommerce' ),
+					'sales' => __( 'Sales', 'genesis-connect-woocommerce' ),
 				),
 			),
 			'order'                   => array(
 				'type'    => 'select',
 				'std'     => esc_html( $this->defaults['order'] ),
-				'label'   => _x( 'Order', 'Sorting Order', 'gencwooc' ),
+				'label'   => _x( 'Order', 'Sorting Order', 'genesis-connect-woocommerce' ),
 				'options' => array(
-					'asc'  => __( 'ASC', 'gencwooc' ),
-					'desc' => __( 'DESC', 'gencwooc' ),
+					'asc'  => __( 'ASC', 'genesis-connect-woocommerce' ),
+					'desc' => __( 'DESC', 'genesis-connect-woocommerce' ),
 				),
 			),
 			'hide_free'               => array(
 				'type'  => 'checkbox',
 				'std'   => absint( $this->defaults['hide_free'] ),
-				'label' => __( 'Hide Free Products', 'gencwooc' ),
+				'label' => __( 'Hide Free Products', 'genesis-connect-woocommerce' ),
 			),
 			'show_hidden'             => array(
 				'type'  => 'checkbox',
 				'std'   => absint( $this->defaults['show_hidden'] ),
-				'label' => __( 'Show Hidden Products', 'gencwooc' ),
+				'label' => __( 'Show Hidden Products', 'genesis-connect-woocommerce' ),
 			),
 			'show_image'              => array(
 				'type'  => 'checkbox',
 				'std'   => absint( $this->defaults['show_image'] ),
-				'label' => __( 'Show Featured Image?', 'gencwooc' ),
+				'label' => __( 'Show Featured Image?', 'genesis-connect-woocommerce' ),
 			),
 			'image_size'              => array(
 				'type'    => 'select',
 				'std'     => esc_html( $this->defaults['image_size'] ),
-				'label'   => __( 'Image Size', 'gencwooc' ),
+				'label'   => __( 'Image Size', 'genesis-connect-woocommerce' ),
 				'options' => $this->get_featured_image_sizes(),
 			),
 			'link_image'              => array(
 				'type'  => 'checkbox',
 				'std'   => absint( $this->defaults['link_image'] ),
-				'label' => __( 'Link Product Image?', 'gencwooc' ),
+				'label' => __( 'Link Product Image?', 'genesis-connect-woocommerce' ),
 			),
 			'show_title'              => array(
 				'type'  => 'checkbox',
 				'std'   => absint( $this->defaults['show_title'] ),
-				'label' => __( 'Show Title?', 'gencwooc' ),
+				'label' => __( 'Show Title?', 'genesis-connect-woocommerce' ),
 			),
 			'show_add_to_cart'        => array(
 				'type'  => 'checkbox',
 				'std'   => absint( $this->defaults['show_add_to_cart'] ),
-				'label' => __( 'Show Add to Cart Button?', 'gencwooc' ),
+				'label' => __( 'Show Add to Cart Button?', 'genesis-connect-woocommerce' ),
 			),
 			'show_price'              => array(
 				'type'  => 'checkbox',
 				'std'   => absint( $this->defaults['show_price'] ),
-				'label' => __( 'Show Price?', 'gencwooc' ),
+				'label' => __( 'Show Price?', 'genesis-connect-woocommerce' ),
 			),
 			'more_from_category'      => array(
 				'type'  => 'checkbox',
 				'std'   => absint( $this->defaults['more_from_category'] ),
-				'label' => __( 'Show Category Archive Link?', 'gencwooc' ),
+				'label' => __( 'Show Category Archive Link?', 'genesis-connect-woocommerce' ),
 			),
 			'more_from_category_text' => array(
 				'type'  => 'text',
 				'std'   => esc_html( $this->defaults['more_from_category_text'] ),
-				'label' => __( 'Link Text:', 'gencwooc' ),
+				'label' => __( 'Link Text:', 'genesis-connect-woocommerce' ),
 			),
 		);
 
@@ -194,7 +194,7 @@ class Gencwooc_Featured_Products extends WC_Widget {
 
 		$cats    = get_terms( 'product_cat' );
 		$options = array(
-			'' => __( 'All Categories', 'gencwooc' ),
+			'' => __( 'All Categories', 'genesis-connect-woocommerce' ),
 		);
 
 		if ( ! empty( $cats ) && ! is_wp_error( $cats ) ) {
@@ -405,7 +405,7 @@ class Gencwooc_Featured_Products extends WC_Widget {
 					$header = '';
 
 					if ( ! empty( $instance['show_title'] ) ) {
-						$title = get_the_title() ? get_the_title() : __( '(no title)', 'gencwooc' );
+						$title = get_the_title() ? get_the_title() : __( '(no title)', 'genesis-connect-woocommerce' );
 
 						/**
 						 * Filter the featured post widget title.


### PR DESCRIPTION
This plugin slug is `genesis-connect-woocommerce`, but current Text Domain is set as `gencwooc`. I also modified the text domain in all these plugin source files. Now text domain is equal to its plugin slug. (see https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains)
