### PR TITLE
Fix svn deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,7 @@ workflows:
             branches:
               only: /^bump-tested-up-to.*/
       - wp-svn/deploy-tested-up-to-bump:
+          context: genesis-svn
           requires:
             - approval-for-deploy-tested-up-to-bump
 
@@ -135,7 +136,7 @@ workflows:
             tags:
               only: /^\d+\.\d+\.\d+$/
             branches:
-              only: /.*/
+              ignore: /.*/
       - checks:
           requires:
             - checkout
@@ -143,9 +144,9 @@ workflows:
             tags:
               only: /^\d+\.\d+\.\d+$/
             branches:
-              only: /.*/
+              ignore: /.*/
       - wp-svn/deploy:
-          dry-run: true
+          context: genesis-svn
           requires:
             - checks
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,120 +1,20 @@
 version: 2.1
 
 orbs:
-  wp-svn: studiopress/wp-svn@0.1
-
-commands:
-  install_dependencies:
-    description: "Install development dependencies."
-    steps:
-      - run: composer install
-
-  mkdir_artifacts:
-    description: "Make Artifacts directory"
-    steps:
-      - run:
-          command: |
-            [ ! -d "/tmp/artifacts" ] && mkdir /tmp/artifacts &>/dev/null
-
-  set_verision_variable:
-    description: "Set the VERSION environment variable"
-    steps:
-      - run:
-          command: |
-            echo "export VERSION=$(grep 'Version:' /tmp/src/genesis-connect-woocommerce.php | awk -F: '{print $2}' | sed 's/^\s//')" >> ${BASH_ENV}
-
-  show_pwd_info:
-    description: "Show information about the current directory"
-    steps:
-      - run: pwd
-      - run: ls -lash
-
-  svn_setup:
-    description: "Setup SVN"
-    steps:
-      - run: echo "export SLUG=genesis-connect-woocommerce" >> ${BASH_ENV}
-      - run: svn co https://plugins.svn.wordpress.org/${SLUG} --depth=empty .
-      - run: svn up trunk
-      - run: svn up tags --depth=empty
-      - run: find ./trunk -not -path "./trunk" -delete
-      - run: cp -r /tmp/src/. ./trunk
-      - run: svn propset svn:ignore -F ./trunk/.svnignore ./trunk
-
-  svn_add_changes:
-    description: "Add changes to SVN"
-    steps:
-      - run:
-          command: if [[ ! -z $(svn st | grep ^\!) ]]; then svn st | grep ^! | awk '{print " --force "$2}' | xargs -0r svn rm; fi
-      - run: svn add --force .
-
-  svn_create_tag:
-    description: "Create a SVN tag"
-    steps:
-      - set_verision_variable
-      - run: svn cp trunk tags/${VERSION}
-
-  svn_commit:
-    description: "Commit changes to SVN"
-    steps:
-      - set_verision_variable
-      - run: svn ci -m "Tagging ${VERSION} from Github" --no-auth-cache --non-interactive --username "${SVN_USERNAME}" --password "${SVN_PASSWORD}"
-
-executors:
-  base:
-    docker:
-      - image: cimg/base:current
-    working_directory: /tmp
-  php_node:
-    docker:
-      - image: cimg/php:7.3-node
-    working_directory: /tmp/src
+  wp-svn: studiopress/wp-svn@0.2
 
 jobs:
-  checkout:
-    executor: base
-    steps:
-      - mkdir_artifacts
-      - checkout:
-          path: src
-      - persist_to_workspace:
-          root: /tmp
-          paths:
-            - src
-
   checks:
-    executor: php_node
+    docker:
+      - image: cimg/php:7.3-node
     steps:
-      - attach_workspace:
-          at: /tmp
-      - install_dependencies
-      - run: composer phpcs
-
-  deploy_svn_tag:
-    executor: base
-    working_directory: /tmp/artifacts
-    steps:
-      - attach_workspace:
-          at: /tmp
-      - svn_setup
-      - svn_create_tag
-      - svn_add_changes
-      - svn_commit
+      - checkout
+      - run: composer i && composer phpcs
 
 workflows:
   test-deploy:
     jobs:
-      - checkout:
-          filters:
-            branches:
-              ignore:
-                - master
-      - checks:
-          requires:
-            - checkout
-          filters:
-            branches:
-              ignore:
-                - master
+      - checks
       - approval-for-deploy-tested-up-to-bump:
           type: approval
           requires:
@@ -125,28 +25,19 @@ workflows:
             branches:
               only: /^bump-tested-up-to.*/
       - wp-svn/deploy-tested-up-to-bump:
-          context: genesis-svn
           requires:
             - approval-for-deploy-tested-up-to-bump
 
   tag_deploy:
     jobs:
-      - checkout:
-          filters:
-            tags:
-              only: /^\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
       - checks:
-          requires:
-            - checkout
           filters:
             tags:
               only: /^\d+\.\d+\.\d+$/
             branches:
-              ignore: /.*/
+              only: /.*/
       - wp-svn/deploy:
-          context: genesis-svn
+          dry-run: true
           requires:
             - checks
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,6 @@ workflows:
             branches:
               only: /^bump-tested-up-to.*/
       - wp-svn/deploy-tested-up-to-bump:
-          context: genesis-svn
           requires:
             - approval-for-deploy-tested-up-to-bump
 
@@ -145,12 +144,12 @@ workflows:
               only: /^\d+\.\d+\.\d+$/
             branches:
               ignore: /.*/
-      - deploy_svn_tag:
-          context: genesis-svn
+      - wp-svn/deploy:
+          dry-run: true
           requires:
             - checks
           filters:
             tags:
               only: /^\d+\.\d+\.\d+$/
             branches:
-              ignore: /.*/
+              only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ workflows:
             tags:
               only: /^\d+\.\d+\.\d+$/
             branches:
-              ignore: /.*/
+              only: /.*/
       - checks:
           requires:
             - checkout
@@ -143,7 +143,7 @@ workflows:
             tags:
               only: /^\d+\.\d+\.\d+$/
             branches:
-              ignore: /.*/
+              only: /.*/
       - wp-svn/deploy:
           dry-run: true
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
   wp-svn: studiopress/wp-svn@0.2
 
 jobs:
-  checks:
+  lint:
     docker:
       - image: cimg/php:7.3-node
     steps:
@@ -14,34 +14,35 @@ jobs:
 workflows:
   test-deploy:
     jobs:
-      - checks
+      - lint
       - approval-for-deploy-tested-up-to-bump:
           type: approval
           requires:
-            - checks
+            - lint
           filters:
             tags:
               ignore: /.*/
             branches:
               only: /^bump-tested-up-to.*/
       - wp-svn/deploy-tested-up-to-bump:
+          context: genesis-svn
           requires:
             - approval-for-deploy-tested-up-to-bump
 
-  tag_deploy:
+  tag-deploy:
     jobs:
-      - checks:
+      - lint:
           filters:
             tags:
               only: /^\d+\.\d+\.\d+$/
             branches:
-              only: /.*/
+              ignore: /.*/
       - wp-svn/deploy:
-          dry-run: true
+          context: genesis-svn
           requires:
-            - checks
+            - lint
           filters:
             tags:
               only: /^\d+\.\d+\.\d+$/
             branches:
-              only: /.*/
+              ignore: /.*/

--- a/.svnignore
+++ b/.svnignore
@@ -3,6 +3,7 @@
 .gitignore
 .gitattributes
 .svnignore
+.circleci
 composer.json
 composer.lock
 node_modules


### PR DESCRIPTION
* The previous deployment [failed](https://app.circleci.com/pipelines/github/studiopress/genesis-connect-woocommerce/33/workflows/e31c7946-8946-4859-acb5-a8a93aefbdce/jobs/660) because `svn` was undefined, because I updated the containers.
* So this uses the [WP SVN](https://circleci.com/developer/orbs/orb/studiopress/wp-svn) orb, where `svn` is defined.

### How to test
Not needed. [Here's what](https://app.circleci.com/pipelines/github/studiopress/genesis-connect-woocommerce/37/workflows/0481c8dc-db9d-4adf-bb3f-e80db0d83762/jobs/81?invite=true#step-105-1607_21) the deployment will have.
