### PR TITLE
Bump 'Tested up to' to `6.5`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: nathanrice, studiopress, studiograsshopper, modernnerd, marksabbath, calvinkoepke, curtismchale, wpengine, dreamwhisper
 Tags: genesis, genesiswp, studiopress, woocommerce
 Requires at least: 4.7
-Tested up to: 6.3
+Tested up to: 6.5
 Stable tag: 1.1.2
 
 This plugin allows you to seamlessly integrate WooCommerce with the Genesis Framework and Genesis child themes.


### PR DESCRIPTION
* Duplicate of https://github.com/studiopress/genesis-connect-woocommerce/pull/67, but with the correct branch to deploy the 'Tested up to' bump
