### PR TITLE
Address readme warnings on wordpress.org

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,11 @@
-=== Plugin Name ===
+=== Genesis Connect for WooCommerce ===
 Contributors: nathanrice, studiopress, studiograsshopper, modernnerd, marksabbath, calvinkoepke, curtismchale, wpengine, dreamwhisper
 Tags: genesis, genesiswp, studiopress, woocommerce
 Requires at least: 4.7
 Tested up to: 6.6
 Stable tag: 1.1.3
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
 This plugin allows you to seamlessly integrate WooCommerce with the Genesis Framework and Genesis child themes.
 


### PR DESCRIPTION
- Corrects title
- Adds license

To address warnings reported in WP.org:

![WP.org warnings for Genesis Connect WooCommerce](https://github.com/user-attachments/assets/7f4dc8a0-8050-47a8-acb6-4988a13f69ef)

### How to test
Paste content of readme.txt here and check for errors (notes are fine, we're just concerned with orange errors).

https://wordpress.org/plugins/developers/readme-validator/

### Documentation

No documentation required.
