### PR TITLE
ci: reinstate 'tested up to' deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
-# orbs:
-  # wp-svn: studiopress/wp-svn@0.2
+orbs:
+  wp-svn: studiopress/wp-svn@0.2
 
 jobs:
   lint:
@@ -15,19 +15,19 @@ workflows:
   test-deploy:
     jobs:
       - lint
-      # - approval-for-deploy-tested-up-to-bump:
-      #     type: approval
-      #     requires:
-      #       - lint
-      #     filters:
-      #       tags:
-      #         ignore: /.*/
-      #       branches:
-      #         only: /^bump-tested-up-to.*/
-      # - wp-svn/deploy-tested-up-to-bump:
-      #     context: genesis-svn
-      #     requires:
-      #       - approval-for-deploy-tested-up-to-bump
+      - approval-for-deploy-tested-up-to-bump:
+          type: approval
+          requires:
+            - lint
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              only: /^bump-tested-up-to.*/
+      - wp-svn/deploy-tested-up-to-bump:
+          context: genesis-svn
+          requires:
+            - approval-for-deploy-tested-up-to-bump
 
   # tag-deploy:
   #   jobs:


### PR DESCRIPTION
WP.org is no longer blocked, we can deploy 'tested up to' updates this way again.
