### PR TITLE
chore: bump tested up to '6.9'

### DIFF
--- a/genesis-connect-woocommerce.php
+++ b/genesis-connect-woocommerce.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Genesis Connect for WooCommerce
  * Plugin URI: https://wordpress.org/plugins/genesis-connect-woocommerce/
- * Version: 1.1.2
+ * Version: 1.1.3
  * Author: StudioPress
  * Author URI: https://www.studiopress.com/
  * Description: Allows you to seamlessly integrate WooCommerce with the Genesis Framework and Genesis child themes.

--- a/genesis-connect-woocommerce.php
+++ b/genesis-connect-woocommerce.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Genesis Connect for WooCommerce
  * Plugin URI: https://wordpress.org/plugins/genesis-connect-woocommerce/
- * Version: 1.1.3
+ * Version: 1.1.2
  * Author: StudioPress
  * Author URI: https://www.studiopress.com/
  * Description: Allows you to seamlessly integrate WooCommerce with the Genesis Framework and Genesis child themes.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: nathanrice, studiopress, studiograsshopper, modernnerd, marksabbat
 Tags: genesis, genesiswp, studiopress, woocommerce
 Requires at least: 4.7
 Tested up to: 6.9
-Stable tag: 1.1.2
+Stable tag: 1.1.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: nathanrice, studiopress, studiograsshopper, modernnerd, marksabbath, calvinkoepke, curtismchale, wpengine, dreamwhisper
 Tags: genesis, genesiswp, studiopress, woocommerce
 Requires at least: 4.7
-Tested up to: 6.6
-Stable tag: 1.1.3
+Tested up to: 6.9
+Stable tag: 1.1.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 


### PR DESCRIPTION
Increase the "tested up to" version to WP 6.9

This mostly mimics the steps articulated in:

https://github.com/studiopress/genesis-beta-tester/pull/26/commits/396122fe3f21dc36b14f63ce9e95d7a0014c1982


